### PR TITLE
Update SDK to 22.08

### DIFF
--- a/com.visualstudio.code.tool.fish.yml
+++ b/com.visualstudio.code.tool.fish.yml
@@ -1,7 +1,7 @@
 id: com.visualstudio.code.tool.fish
-branch: '21.08'
+branch: '22.08'
 build-extension: true
-sdk: org.freedesktop.Sdk//21.08
+sdk: org.freedesktop.Sdk//22.08
 runtime: com.visualstudio.code
 runtime-version: stable
 separate-locales: false


### PR DESCRIPTION
Necessary to work with newest version of Visual Studio Code, see https://github.com/flathub/com.visualstudio.code/issues/351 for a related issue fixed this way.